### PR TITLE
Frees the SoundFile object when an entry is not approved yet

### DIFF
--- a/code/libs/dynamic_yamling.scd
+++ b/code/libs/dynamic_yamling.scd
@@ -52,7 +52,11 @@ q.updateEntries = {
 					// this will load newly approved yamls when approved
 					if (dict.approved == "true") {
 						q.mainDict.put(nameKey, dict);
-					};
+					} { 
+                        // if not approved, discards the soundfile object otherwise it won't be freed in memory
+                        if (soundfile.notNil) {
+                            soundfile.close;
+                        };
 					// "q.mainDict has % entries.\n".postf(q.mainDict.size);
 				} {
 					"*** no soundfile for % !!\n".postf(nameKey.cs);
@@ -60,6 +64,10 @@ q.updateEntries = {
 			} { |error|
 				// error.dump;
 				"*** yaml or soundfile read failed for % !!\n".postf(nameKey.cs);
+                // just to guarantee, frees the soundfile
+                if (soundfile.notNil) {
+                    soundfile.close;
+                };
 			}
 		}
 	};

--- a/code/libs/dynamic_yamling.scd
+++ b/code/libs/dynamic_yamling.scd
@@ -52,11 +52,12 @@ q.updateEntries = {
 					// this will load newly approved yamls when approved
 					if (dict.approved == "true") {
 						q.mainDict.put(nameKey, dict);
-					} { 
-                        // if not approved, discards the soundfile object otherwise it won't be freed in memory
-                        if (soundfile.notNil) {
-                            soundfile.close;
-                        };
+					} {
+						// if not approved, discards the soundfile object otherwise it won't be freed in memory
+						if (soundfile.notNil) {
+							soundfile.close;
+						};
+					};
 					// "q.mainDict has % entries.\n".postf(q.mainDict.size);
 				} {
 					"*** no soundfile for % !!\n".postf(nameKey.cs);
@@ -64,10 +65,10 @@ q.updateEntries = {
 			} { |error|
 				// error.dump;
 				"*** yaml or soundfile read failed for % !!\n".postf(nameKey.cs);
-                // just to guarantee, frees the soundfile
-                if (soundfile.notNil) {
-                    soundfile.close;
-                };
+				// just to guarantee, frees the soundfile
+				if (soundfile.notNil) {
+					soundfile.close;
+				};
 			}
 		}
 	};


### PR DESCRIPTION
If we don't free the sound file when the entry isn't approved, it will keep loading new SoundFile objects every time causing a memory leak.